### PR TITLE
Adding Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM shipimg/rdsbase:master.698


### PR DESCRIPTION
Add a Dockerfile with the version of `shipimg/rdsbase` currently used as the base image.